### PR TITLE
Fixed typos in the docs

### DIFF
--- a/docs/api/icon.md
+++ b/docs/api/icon.md
@@ -1,7 +1,7 @@
 [themes]: https://1foreverhd.github.io/TopbarPlus/features/#themes
 [set method]: https://1foreverhd.github.io/TopbarPlus/api/icon/#set
 
-## Construtors
+## Constructors
 
 #### new
 ```lua
@@ -20,7 +20,7 @@ Constructs an empty ``32x32`` icon on the topbar.
 ```lua
 icon:set(settingName, value, iconState)
 ```
-Applies a specific setting to an icon. All settings can be found [here](https://github.com/1ForeverHD/TopbarPlus/blob/main/src/Icon/Themes/Default.lua). If the setting falls under the 'toggleable' category then an iconState can be specified. For most scenarious it's recommended instead to apply settings using [themes].
+Applies a specific setting to an icon. All settings can be found [here](https://github.com/1ForeverHD/TopbarPlus/blob/main/src/Icon/Themes/Default.lua). If the setting falls under the 'toggleable' category then an iconState can be specified. For most scenarios it's recommended instead to apply settings using [themes].
 
 ----
 #### get
@@ -144,7 +144,7 @@ Icon.new()
 ```lua
 icon:setImage(imageId, iconState)
 ```
-Applies an image to the icon based on the given ``imaageId``. ``imageId`` can be an assetId or a complete asset string.
+Applies an image to the icon based on the given ``imageId``. ``imageId`` can be an assetId or a complete asset string.
 
 ----
 #### setLabel
@@ -218,7 +218,7 @@ Defines how large label text appears.By default ``YScale`` is ``0.45``.
 ```lua
 icon:setBaseZIndex(ZIndex, iconState)
 ```
-Calculates the difference between the existing baseZIndex (i.e. ``instances.iconContainer.ZIndex``) and new value, then updates the ZIndex of all objects within the icon accoridngly using this difference.
+Calculates the difference between the existing baseZIndex (i.e. ``instances.iconContainer.ZIndex``) and new value, then updates the ZIndex of all objects within the icon accordingly using this difference.
 
 ----
 #### setSize

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -7,7 +7,7 @@
 
 ## Bug Reports
 - To submit a bug report, [open an issue] with label ``Type: Bug`` or create a response at the [discussion thread].
-- Ensure your report includes a detailed explanation of the problem with any relavent images, videos, etc (such as console errors).
+- Ensure your report includes a detailed explanation of the problem with any relevant images, videos, etc (such as console errors).
 - Make sure to include a link to a stipped-down uncopylocked Roblox place which reproduces the bug.
 
 ## Questions and Feedback

--- a/docs/features.md
+++ b/docs/features.md
@@ -229,7 +229,7 @@ icon:setRight()
 ------------------------------
 
 ### Overflows
-When accounting for many device types and screen sizes, icons may occassionally, particularly for smaller devices like phones, overlap with other icons or the bounds of the screen. TopbarPlus solves this problem with automatic overflows which prevent overlaps occuring.
+When accounting for many device types and screen sizes, icons may occasionally, particularly for smaller devices like phones, overlap with other icons or the bounds of the screen. TopbarPlus solves this problem with automatic overflows which prevent overlaps occuring.
 
 An overflow will appear when left-set or right-set icons exceed the boundary of the:
 


### PR DESCRIPTION
## Just fixed roughly 6 typos I could find around the docs.

### Changes:
- Changed `occassionally` > `occasionally`
- Changed `Construtors` > `Constructors`
- Changed `scenarious` > `scenarios`
- Changed `imaageId` > `imageId`
- Changed `accoridngly` > `accordingly`
- Changed `relavent` > `relevant`

