### PR TITLE
Modernize Signal with FastSignal

### DIFF
--- a/src/Icon/Signal.lua
+++ b/src/Icon/Signal.lua
@@ -290,7 +290,7 @@ function ScriptSignal:DisconnectAll()
 end
 
 --[=[
-	Destroys a ScriptSignal object, disconnecting all connection and making it unusable.
+	Destroys a ScriptSignal object, disconnecting all connections and making it unusable.
 
 	```lua
 	ScriptSignal:Destroy()

--- a/src/Icon/Signal.lua
+++ b/src/Icon/Signal.lua
@@ -1,34 +1,39 @@
 --[=[
+	A class which holds data and methods for ScriptSignals.
+
 	@class ScriptSignal
 ]=]
 local ScriptSignal = {}
 ScriptSignal.__index = ScriptSignal
 
 --[=[
+	A class which holds data and methods for ScriptConnections.
+
 	@class ScriptConnection
 ]=]
 local ScriptConnection = {}
 ScriptConnection.__index = ScriptConnection
 
 --[=[
-	@prop Connected boolean
-	@readonly
-	@within ScriptConnection
-	@ignore
+	A boolean which determines if a ScriptConnection is active or not.
 
-	A boolean which determines if a ScriptConnection is active or not
+	@prop Connected boolean
+	@within ScriptConnection
+
+	@readonly
+	@ignore
 ]=]
 
 local FreeThread: thread? = nil
 
 local function RunHandlerInFreeThread(
-	handle: (...any) -> (),
-	...
+	handler: (...any) -> (),
+	...: any
 )
 	local thread = FreeThread :: thread
 	FreeThread = nil
 
-	handle(...)
+	handler(...)
 
 	FreeThread = thread
 end
@@ -42,7 +47,7 @@ local function CreateFreeThread()
 end
 
 --[=[
-	Creates a ScriptSignal object
+	Creates a ScriptSignal object.
 
 	@return ScriptSignal
 	@ignore
@@ -55,7 +60,7 @@ function ScriptSignal.new()
 end
 
 --[=[
-	Returns a boolean determining if the object is a ScriptSignal
+	Returns a boolean determining if the object is a ScriptSignal.
 
 	```lua
 	local janitor = Janitor.new()
@@ -75,7 +80,7 @@ function ScriptSignal.Is(object): boolean
 end
 
 --[=[
-	Returns a boolean determing if a ScriptSignal object is active
+	Returns a boolean determing if a ScriptSignal object is active.
 
 	```lua
 	ScriptSignal:IsActive() -> true
@@ -91,7 +96,7 @@ function ScriptSignal:IsActive(): boolean
 end
 
 --[=[
-	Connects a function to the ScriptSignal
+	Connects a handler to a ScriptSignal object.
 
 	```lua
 	ScriptSignal:Connect(function(text)
@@ -104,15 +109,15 @@ end
 	-- "Something" and then "Something else" are printed
 	```
 
-	@param handle (...: any) -> ()
+	@param handler (...: any) -> ()
 	@return ScriptConnection
 	@ignore
 ]=]
 function ScriptSignal:Connect(
-	handle: (...any) -> ()
+	handler: (...any) -> ()
 )
 	assert(
-		typeof(handle) == 'function',
+		typeof(handler) == 'function',
 		"Must be function"
 	)
 
@@ -127,7 +132,7 @@ function ScriptSignal:Connect(
 	local node = {
 		_signal = self,
 		_connection = nil,
-		_handle = handle,
+		_handler = handler,
 
 		_next = _head,
 		_prev = nil
@@ -149,8 +154,8 @@ function ScriptSignal:Connect(
 end
 
 --[=[
-	Connects a function to a ScriptSignal object, but only allows that
-	connection to run once. any later fire calls won't trigger anything
+	Connects a handler to a ScriptSignal object, but only allows that
+	connection to run once. Any `:Fire` calls called afterwards won't trigger anything.
 
 	```lua
 	ScriptSignal:ConnectOnce(function()
@@ -163,19 +168,19 @@ end
 	-- "Connection fired" is only fired once
 	```
 
-	@param handle (...: any) -> ()
+	@param handler (...: any) -> ()
 	@ignore
 ]=]
 function ScriptSignal:ConnectOnce(
-	handle: (...any) -> ()
+	handler: (...any) -> ()
 )
 	assert(
-		typeof(handle) == 'function',
+		typeof(handler) == 'function',
 		"Must be function"
 	)
 
 	local connection
-	connection = self:Connect(function(...)
+	connection = self:Connect(function(...: any)
 		if connection == nil then
 			return
 		end
@@ -183,12 +188,12 @@ function ScriptSignal:ConnectOnce(
 		connection:Disconnect()
 		connection = nil
 
-		handle(...)
+		handler(...)
 	end)
 end
 
 --[=[
-	Yields the thread until a fire call happens, returns what the signal was fired with
+	Yields the thread until a `:Fire` call occurs, returns what the signal was fired with.
 
 	```lua
 	task.spawn(function()
@@ -210,7 +215,7 @@ function ScriptSignal:Wait(): (...any)
 		thread = coroutine.running()
 
 		local connection
-		connection = self:Connect(function(...)
+		connection = self:Connect(function(...: any)
 			if connection == nil then
 				return
 			end
@@ -226,7 +231,7 @@ function ScriptSignal:Wait(): (...any)
 end
 
 --[=[
-	Fires a ScriptSignal object with the arguments passed through it
+	Fires a ScriptSignal object with the arguments passed through it.
 
 	```lua
 	ScriptSignal:Connect(function(text)
@@ -241,7 +246,7 @@ end
 	@param ... any
 	@ignore
 ]=]
-function ScriptSignal:Fire(...)
+function ScriptSignal:Fire(...: any)
 	local node = self._head
 	while node ~= nil do
 		if node._connection ~= nil then
@@ -251,7 +256,7 @@ function ScriptSignal:Fire(...)
 
 			task.spawn(
 				FreeThread :: thread,
-				node._handle, ...
+				node._handler, ...
 			)
 		end
 
@@ -260,16 +265,13 @@ function ScriptSignal:Fire(...)
 end
 
 --[=[
-	Disconnects all connections from a ScriptSignal object
-	without destroying it and without making it unusable
+	Disconnects all connections from a ScriptSignal object without making it unusable.
 
 	```lua
 	local connection = ScriptSignal:Connect(function() end)
 
 	connection.Connected -> true
-
 	ScriptSignal:DisconnectAll()
-
 	connection.Connected -> false
 	```
 
@@ -288,8 +290,7 @@ function ScriptSignal:DisconnectAll()
 end
 
 --[=[
-	Destroys a ScriptSignal object, disconnecting all connections
-	and making it unusable.
+	Destroys a ScriptSignal object, disconnecting all connection and making it unusable.
 
 	```lua
 	ScriptSignal:Destroy()
@@ -310,16 +311,14 @@ function ScriptSignal:Destroy()
 end
 
 --[=[
-	Disconnects a connection, any :Fire calls from now on would not
-	invoke this connection's function
+	Disconnects a connection, any `:Fire` calls from now on will not
+	invoke this connection's handler.
 
 	```lua
 	local connection = ScriptSignal:Connect(function() end)
 
 	connection.Connected -> true
-
 	connection:Disconnect()
-
 	connection.Connected -> false
 	```
 

--- a/src/Icon/Signal.lua
+++ b/src/Icon/Signal.lua
@@ -1,109 +1,375 @@
-local HttpService = game:GetService("HttpService")
-local RunService = game:GetService("RunService")
-local heartbeat = RunService.Heartbeat
-local Signal = {}
-Signal.__index = Signal
-Signal.ClassName = "Signal"
-Signal.totalConnections = 0
+--[=[
+	@class ScriptSignal
+]=]
+local ScriptSignal = {}
+ScriptSignal.__index = ScriptSignal
 
+--[=[
+	@class ScriptConnection
+]=]
+local ScriptConnection = {}
+ScriptConnection.__index = ScriptConnection
 
+--[=[
+	@prop Connected boolean
+	@readonly
+	@within ScriptConnection
+	@ignore
 
--- CONSTRUCTOR
-function Signal.new(createConnectionsChangedSignal)
-	local self = setmetatable({}, Signal)
-	
-	if createConnectionsChangedSignal then
-		self.connectionsChanged = Signal.new()
-	end
+	A boolean which determines if a ScriptConnection is active or not
+]=]
 
-	self.connections = {}
-	self.totalConnections = 0
-	self.waiting = {}
-	self.totalWaiting = 0
+local FreeThread: thread? = nil
 
-	return self
+local function RunHandlerInFreeThread(
+	handle: (...any) -> (),
+	...
+)
+	local thread = FreeThread :: thread
+	FreeThread = nil
+
+	handle(...)
+
+	FreeThread = thread
 end
 
+local function CreateFreeThread()
+	FreeThread = coroutine.running()
 
-
--- METHODS
-function Signal:Fire(...)
-	for _, connection in pairs(self.connections) do
-		connection.Handler(...)
-	end
-	if self.totalWaiting > 0 then
-		local packedArgs = table.pack(...)
-		for waitingId, _ in pairs(self.waiting) do
-			self.waiting[waitingId] = packedArgs
-		end
+	while true do
+		RunHandlerInFreeThread( coroutine.yield() )
 	end
 end
-Signal.fire = Signal.Fire
 
-function Signal:Connect(handler)
-	if not (type(handler) == "function") then
-		error(("connect(%s)"):format(typeof(handler)), 2)
-	end
-	
-	local signal = self
-	local connectionId = HttpService:GenerateGUID(false)
-	local connection = {}
-	connection.Connected = true
-	connection.ConnectionId = connectionId
-	connection.Handler = handler
-	self.connections[connectionId] = connection
+--[=[
+	Creates a ScriptSignal object
 
-	function connection:Disconnect()
-		signal.connections[connectionId] = nil
-		connection.Connected = false
-		signal.totalConnections -= 1
-		if signal.connectionsChanged then
-			signal.connectionsChanged:Fire(-1)
-		end
+	@return ScriptSignal
+	@ignore
+]=]
+function ScriptSignal.new()
+	return setmetatable({
+		_active = true,
+		_head = nil
+	}, ScriptSignal)
+end
+
+--[=[
+	Returns a boolean determining if the object is a ScriptSignal
+
+	```lua
+	local janitor = Janitor.new()
+	local signal = ScriptSignal.new()
+
+	ScriptSignal.Is(signal) -> true
+	ScriptSignal.Is(janitor) -> false
+	```
+
+	@param object any
+	@return boolean
+	@ignore
+]=]
+function ScriptSignal.Is(object): boolean
+	return typeof(object) == 'table'
+		and getmetatable(object) == ScriptSignal
+end
+
+--[=[
+	Returns a boolean determing if a ScriptSignal object is active
+
+	```lua
+	ScriptSignal:IsActive() -> true
+	ScriptSignal:Destroy()
+	ScriptSignal:IsActive() -> false
+	```
+
+	@return boolean
+	@ignore
+]=]
+function ScriptSignal:IsActive(): boolean
+	return self._active == true
+end
+
+--[=[
+	Connects a function to the ScriptSignal
+
+	```lua
+	ScriptSignal:Connect(function(text)
+		print(text)
+	end)
+
+	ScriptSignal:Fire("Something")
+	ScriptSignal:Fire("Something else")
+
+	-- "Something" and then "Something else" are printed
+	```
+
+	@param handle (...: any) -> ()
+	@return ScriptConnection
+	@ignore
+]=]
+function ScriptSignal:Connect(
+	handle: (...any) -> ()
+)
+	assert(
+		typeof(handle) == 'function',
+		"Must be function"
+	)
+
+	if self._active == false then
+		return setmetatable({
+			Connected = false
+		}, ScriptConnection)
 	end
-	connection.Destroy = connection.Disconnect
-	connection.destroy = connection.Disconnect
-	connection.disconnect = connection.Disconnect
-	self.totalConnections += 1
-	if self.connectionsChanged then
-		self.connectionsChanged:Fire(1)
+
+	local _head = self._head
+
+	local node = {
+		_signal = self,
+		_connection = nil,
+		_handle = handle,
+
+		_next = _head,
+		_prev = nil
+	}
+
+	if _head then
+		_head._prev = node
 	end
+	self._head = node
+
+	local connection = setmetatable({
+		Connected = true,
+		_node = node
+	}, ScriptConnection)
+
+	node._connection = connection
 
 	return connection
 end
-Signal.connect = Signal.Connect
 
-function Signal:Wait()
-	local waitingId = HttpService:GenerateGUID(false)
-	self.waiting[waitingId] = true
-	self.totalWaiting += 1
-	repeat heartbeat:Wait() until self.waiting[waitingId] ~= true
-	self.totalWaiting -= 1
-	local args = self.waiting[waitingId]
-	self.waiting[waitingId] = nil
-	return unpack(args)
+--[=[
+	Connects a function to a ScriptSignal object, but only allows that
+	connection to run once. any later fire calls won't trigger anything
+
+	```lua
+	ScriptSignal:ConnectOnce(function()
+		print("Connection fired")
+	end)
+
+	ScriptSignal:Fire()
+	ScriptSignal:Fire()
+
+	-- "Connection fired" is only fired once
+	```
+
+	@param handle (...: any) -> ()
+	@ignore
+]=]
+function ScriptSignal:ConnectOnce(
+	handle: (...any) -> ()
+)
+	assert(
+		typeof(handle) == 'function',
+		"Must be function"
+	)
+
+	local connection
+	connection = self:Connect(function(...)
+		if connection == nil then
+			return
+		end
+
+		connection:Disconnect()
+		connection = nil
+
+		handle(...)
+	end)
 end
-Signal.wait = Signal.Wait
 
-function Signal:Destroy()
-	if self.bindableEvent then
-		self.bindableEvent:Destroy()
-		self.bindableEvent = nil
+--[=[
+	Yields the thread until a fire call happens, returns what the signal was fired with
+
+	```lua
+	task.spawn(function()
+		print(
+			ScriptSignal:Wait()
+		)
+	end)
+
+	ScriptSignal:Fire("Arg", nil, 1, 2, 3, nil)
+	-- "Arg", nil, 1, 2, 3, nil are printed
+	```
+
+	@yields
+	@return ...any
+	@ignore
+]=]
+function ScriptSignal:Wait(): (...any)
+	local thread do
+		thread = coroutine.running()
+
+		local connection
+		connection = self:Connect(function(...)
+			if connection == nil then
+				return
+			end
+
+			connection:Disconnect()
+			connection = nil
+
+			task.spawn(thread, ...)
+		end)
 	end
-	if self.connectionsChanged then
-		self.connectionsChanged:Fire(-self.totalConnections)
-		self.connectionsChanged:Destroy()
-		self.connectionsChanged = nil
-	end
-	self.totalConnections = 0
-	for connectionId, connection in pairs(self.connections) do
-		self.connections[connectionId] = nil
+
+	return coroutine.yield()
+end
+
+--[=[
+	Fires a ScriptSignal object with the arguments passed through it
+
+	```lua
+	ScriptSignal:Connect(function(text)
+		print(text)
+	end)
+
+	ScriptSignal:Fire("Some Text...")
+
+	-- "Some Text..." is printed twice
+	```
+
+	@param ... any
+	@ignore
+]=]
+function ScriptSignal:Fire(...)
+	local node = self._head
+	while node ~= nil do
+		if node._connection ~= nil then
+			if FreeThread == nil then
+				task.spawn(CreateFreeThread)
+			end
+
+			task.spawn(
+				FreeThread :: thread,
+				node._handle, ...
+			)
+		end
+
+		node = node._next
 	end
 end
-Signal.destroy = Signal.Destroy
-Signal.Disconnect = Signal.Destroy
-Signal.disconnect = Signal.Destroy
 
+--[=[
+	Disconnects all connections from a ScriptSignal object
+	without destroying it and without making it unusable
 
+	```lua
+	local connection = ScriptSignal:Connect(function() end)
 
-return Signal
+	connection.Connected -> true
+
+	ScriptSignal:DisconnectAll()
+
+	connection.Connected -> false
+	```
+
+	@ignore
+]=]
+function ScriptSignal:DisconnectAll()
+	local node = self._head
+	while node ~= nil do
+		local _connection = self._connection
+		if _connection ~= nil then
+			_connection:Disconnect()
+		end
+
+		node = node._next
+	end
+end
+
+--[=[
+	Destroys a ScriptSignal object, disconnecting all connections
+	and making it unusable.
+
+	```lua
+	ScriptSignal:Destroy()
+
+	local connection = ScriptSignal:Connect(function() end)
+	connection.Connected -> false
+	```
+
+	@ignore
+]=]
+function ScriptSignal:Destroy()
+	if self._active == false then
+		return
+	end
+
+	self:DisconnectAll()
+	self._active = false
+end
+
+--[=[
+	Disconnects a connection, any :Fire calls from now on would not
+	invoke this connection's function
+
+	```lua
+	local connection = ScriptSignal:Connect(function() end)
+
+	connection.Connected -> true
+
+	connection:Disconnect()
+
+	connection.Connected -> false
+	```
+
+	@ignore
+]=]
+function ScriptConnection:Disconnect()
+	if self.Connected == false then
+		return
+	end
+
+	self.Connected = false
+
+	local _node = self._node
+	local _prev = self._prev
+	local _next = self._next
+
+	if _next then
+		_next._prev = _prev
+	end
+
+	if _prev then
+		_prev._next = _next
+	else
+		-- _node == _signal._head
+
+		_node._signal._head = _next
+	end
+
+	_node._connection = nil
+	self._node = nil
+end
+
+-- Compatibility methods for TopbarPlus
+ScriptConnection.destroy = ScriptConnection.Disconnect
+ScriptConnection.Destroy = ScriptConnection.Disconnect
+ScriptConnection.disconnect = ScriptConnection.Disconnect
+ScriptSignal.destroy = ScriptSignal.Destroy
+ScriptSignal.Disconnect = ScriptSignal.Destroy
+ScriptSignal.disconnect = ScriptSignal.Destroy
+
+ScriptSignal.connect = ScriptSignal.Connect
+ScriptSignal.wait = ScriptSignal.Wait
+ScriptSignal.fire = ScriptSignal.Fire
+
+export type Class = typeof(
+	ScriptSignal.new()
+)
+
+export type ScriptConnection = typeof(
+	ScriptSignal.new():Connect(function() end)
+)
+
+return ScriptSignal

--- a/src/Icon/Signal.lua
+++ b/src/Icon/Signal.lua
@@ -221,7 +221,7 @@ function ScriptSignal:Wait(): (...any)
 end
 
 --[=[
-	Fires a ScriptSignal object with the arguments passed through it.
+	Fires a ScriptSignal object with the arguments passed.
 
 	```lua
 	ScriptSignal:Connect(function(text)
@@ -270,13 +270,18 @@ end
 function ScriptSignal:DisconnectAll()
 	local node = self._head
 	while node ~= nil do
-		local _connection = self._connection
+		local _connection = node._connection
+
 		if _connection ~= nil then
-			_connection:Disconnect()
+			_connection.Connected = false
+			_connection._node = nil
+			node._connection = nil
 		end
 
 		node = node._next
 	end
+
+	self._head = nil
 end
 
 --[=[
@@ -315,7 +320,7 @@ end
 	@ignore
 ]=]
 function ScriptConnection:Disconnect()
-	if self.Connected == false then
+	if self.Connected ~= true then
 		return
 	end
 

--- a/src/Icon/Signal.lua
+++ b/src/Icon/Signal.lua
@@ -121,7 +121,7 @@ function ScriptSignal:Connect(
 		"Must be function"
 	)
 
-	if self._active == false then
+	if self._active ~= true then
 		return setmetatable({
 			Connected = false
 		}, ScriptConnection)
@@ -181,12 +181,7 @@ function ScriptSignal:ConnectOnce(
 
 	local connection
 	connection = self:Connect(function(...: any)
-		if connection == nil then
-			return
-		end
-
 		connection:Disconnect()
-		connection = nil
 
 		handler(...)
 	end)
@@ -216,12 +211,7 @@ function ScriptSignal:Wait(): (...any)
 
 		local connection
 		connection = self:Connect(function(...: any)
-			if connection == nil then
-				return
-			end
-
 			connection:Disconnect()
-			connection = nil
 
 			task.spawn(thread, ...)
 		end)
@@ -302,7 +292,7 @@ end
 	@ignore
 ]=]
 function ScriptSignal:Destroy()
-	if self._active == false then
+	if self._active ~= true then
 		return
 	end
 


### PR DESCRIPTION
Closes #40

* Fixes yielding connection issues
* Fixes `:Disconnect` issues when inside a connection handler

I done some really basic testing, and as far as I know nothing breaks, but it was a really basic one, if you have any rich tests, I suggest you try testing TopbarPlus with it and seeing if anything breaks.

Any code that broke because of the Signal change from when it was using BindableEvents should know work again, and and *some* code from now which yields inside connections *can* break, but it was unexpected behaviour anyway, so... :P
If anyone complains from some bug on their code, let them know it's because connections made other connections delay themselves until the other one was done, and so now their code should know how to handle that properly.

Not sure if you will merge this because of your syntax style choice but I hope it's fine 😅