### PR TITLE
Allow TopbarPlus to be used as a git submodule

### DIFF
--- a/default.project.json
+++ b/default.project.json
@@ -1,14 +1,6 @@
 {
-  "name": "TopbarPlus",
-  "tree": {
-    "$className": "DataModel",
-
-    "ReplicatedStorage": {
-      "$className": "ReplicatedStorage",
-
-      "Icon": {
-        "$path": "src/Icon"
-      }
+    "name": "TopbarPlus",
+    "tree": {
+        "$path": "src"
     }
-  }
 }


### PR DESCRIPTION
This would allow Topbar Plus to be imported as a git submodule for Rojo users, while requiring no changes to the source code for changing it's location.