### PR TITLE
Fix syntax highlighting on github

### DIFF
--- a/src/Icon/init.lua
+++ b/src/Icon/init.lua
@@ -29,7 +29,7 @@
 	   changes then calling as a singular, utilizing inbuilt Roblox features
 	   such as UILIstLayouts, etc)
 
---]]
+]]
 
 
 


### PR DESCRIPTION
Before ![image](https://github.com/1ForeverHD/TopbarPlus/assets/142684596/1e5b4be8-d5c2-48e4-ade0-8fef3f5c472f)
Fixed ![image](https://github.com/1ForeverHD/TopbarPlus/assets/142684596/e2caa875-5cfe-4abb-b886-252582bb752b)
