### PR TITLE
feat: pass all 3 arguments required by Janitor:Add()

### DIFF
--- a/src/Icon/init.lua
+++ b/src/Icon/init.lua
@@ -913,8 +913,8 @@ function Icon:call(callback, ...)
 	return self
 end
 
-function Icon:addToJanitor(callback)
-	self.janitor:add(callback)
+function Icon:addToJanitor(object, methodName, index)
+	self.janitor:add(object, methodName, index)
 	return self
 end
 


### PR DESCRIPTION
pass all 3 arguments into internally used janitor's :Add() method, so people could specify Index and MethodName to be called.