### PR TITLE
Fixed wally package .project.json mismatch

### DIFF
--- a/default.project.json
+++ b/default.project.json
@@ -1,19 +1,6 @@
 {
-  "name": "topbarplus",
-  "tree": {
-    "$className": "DataModel",
-
-    "ReplicatedStorage": {
-      "$className": "ReplicatedStorage",
-
-      "TopbarPlus": {
-        "$className": "Folder",
-
-        "Icon": {
-          "$path": "src/Icon"
-        }
-
-      }
+    "name": "topbarplus",
+    "tree": {
+        "$path": "src/Icon"
     }
-  }
 }

--- a/serve.project.json
+++ b/serve.project.json
@@ -1,0 +1,18 @@
+{
+    "name": "topbarplus",
+    "tree": {
+        "$className": "DataModel",
+
+        "ReplicatedStorage": {
+            "$className": "ReplicatedStorage",
+
+            "TopbarPlus": {
+                "$className": "Folder",
+
+                "Icon": {
+                    "$path": "src/Icon"
+                }
+            }
+        }
+    }
+}

--- a/src/default.project.json
+++ b/src/default.project.json
@@ -1,6 +1,0 @@
-{
-    "name": "Icon",
-    "tree": {
-        "$path": "Icon"
-    }
-}


### PR DESCRIPTION
Because wally tried to add `default.project.json` ReplicatedStorage to her package, there was an incompatibility, and for this reason Rojo was creating packages files in many different ways and breaking the hierarchy

![image](https://github.com/1ForeverHD/TopbarPlus/assets/121735715/bb429571-0db8-4a43-a214-1801bea67bd8)
