### PR TITLE
Enhancement: Keycode Icon instead of string

### DIFF
--- a/src/Icon/Elements/Caption.lua
+++ b/src/Icon/Elements/Caption.lua
@@ -178,7 +178,7 @@ return function(icon)
 		captionHeader.Text = text
 		captionHeader.Visible = not hideHeader
 		if keyCodeEnum then
-			labelContent.Text = keyCodeEnum.Name
+			labelContent.Text = UserInputService:GetStringForKeyCode(keyCodeEnum)
 			hotkeys.Visible = true
 		end
 		if not hasKeyboard then


### PR DESCRIPTION
Implemented the enhancement from this issue: https://github.com/1ForeverHD/TopbarPlus/issues/110#issue-2261210091

Now, instead of showing the name, it will show the icon of the Key code instead that is returned from the [UserInputService:GetStringForKeyCode](https://create.roblox.com/docs/reference/engine/classes/UserInputService#GetStringForKeyCode) method

All it took was changing one line of code.