### PR TITLE
Add "Resources" page to sidebar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,4 +63,5 @@ nav:
     - Installation: installation.md
     - Third Parties: third_parties.md
     - API: api.md
+    - Resources: resources.md
   - Contributing: contributing.md


### PR DESCRIPTION
The Resources page is not linked in the website sidebar, but it is linked on the contributing page in the article itself. This adds it to the yml config file.