### PR TITLE
new API function

### DIFF
--- a/src/Elements/Dropdown.lua
+++ b/src/Elements/Dropdown.lua
@@ -278,6 +278,7 @@ return function(icon)
 	local function connectVisibilityListeners(child)
 		if child:IsA("GuiObject") then
 			child:GetPropertyChangedSignal("Visible"):Connect(updateChildSize)
+			child:GetPropertyChangedSignal("Size"):Connect(updateChildSize) -- -- update max icons when child size changes
 		end
 	end
 	

--- a/src/init.lua
+++ b/src/init.lua
@@ -841,6 +841,18 @@ function Icon:setTextFont(font, fontWeight, fontStyle, iconState)
 	return self
 end
 
+function Icon:setTextColor(Color, iconState)
+	if Color == nil or Color == "" or (type(Color) ~= "userdata" or typeof(Color) ~= "Color3") then
+		if Color ~= nil and Color ~= "" then
+			warn("setTextColor item must be a Color3 value! Changed the color to white.")
+		end
+		Color = Color3.fromRGB(255, 255, 255)
+	end
+
+	self:modifyTheme({"IconLabel", "TextColor3", Color, iconState})
+	return self
+end
+
 function Icon:bindToggleItem(guiObjectOrLayerCollector)
 	if not guiObjectOrLayerCollector:IsA("GuiObject") and not guiObjectOrLayerCollector:IsA("LayerCollector") then
 		error("Toggle item must be a GuiObject or LayerCollector!")


### PR DESCRIPTION
Function: `:setTextColor(Color3)`

This feature would be an easier way to change the text color without having to use modifytheme.

Example:
```lua
local container  = script.Parent
local Icon = require(container.Icon)

local icon = Icon.new()
icon:setLabel("Example")
icon:setTextColor(Color3.fromRGB(255, 32, 270))
```
<img width="148" height="74" alt="Captura de pantalla 2025-08-19 223134" src="https://github.com/user-attachments/assets/f010146e-15ac-4ae9-81cb-92ce9c742d0d" />
