### PR TITLE
Set DisplayOrder in Container.lua

### DIFF
--- a/src/Elements/Container.lua
+++ b/src/Elements/Container.lua
@@ -134,7 +134,7 @@ return function(Icon)
 	
 	local screenGuiClipped = screenGui:Clone()
 	screenGuiClipped.Name = screenGuiClipped.Name.."Clipped"
-	screenGuiClipped.DisplayOrder = Icon.baseDisplayOrder + 1
+	screenGuiClipped.DisplayOrder = (Icon.baseDisplayOrder + 1)
 	Icon.baseDisplayOrderChanged:Connect(function()
 		screenGuiClipped.DisplayOrder = (Icon.baseDisplayOrder + 1)
 	end)
@@ -144,7 +144,7 @@ return function(Icon)
 	screenGuiCenterClipped.Name = screenGuiCenterClipped.Name.."Clipped"
 	screenGuiCenterClipped.DisplayOrder = (Icon.baseDisplayOrder + 1)
 	Icon.baseDisplayOrderChanged:Connect(function()
-		screenGuiCenterClipped.DisplayOrder = Icon.baseDisplayOrder + 1
+		screenGuiCenterClipped.DisplayOrder = (Icon.baseDisplayOrder + 1)
 	end)
 	container[screenGuiCenterClipped.Name] = screenGuiCenterClipped
 	

--- a/src/Elements/Container.lua
+++ b/src/Elements/Container.lua
@@ -95,6 +95,7 @@ return function(Icon)
 	end)
 	screenGui.Name = "TopbarStandard"
 	screenGui.Enabled = true
+	screenGui.DisplayOrder = Icon.baseDisplayOrder
 	screenGui.ZIndexBehavior = Enum.ZIndexBehavior.Sibling
 	screenGui.IgnoreGuiInset = true
 	screenGui.ResetOnSpawn = false
@@ -121,6 +122,7 @@ return function(Icon)
 		holdersCenter.Size = UDim2.new(1, 0, 0, GuiService.TopbarInset.Height+ySizeOffset)
 	end
 	screenGuiCenter.Name = "TopbarCentered"
+	screenGuiCenter.DisplayOrder = Icon.baseDisplayOrder
 	screenGuiCenter.ScreenInsets = Enum.ScreenInsets.None
 	Icon.baseDisplayOrderChanged:Connect(function()
 		screenGuiCenter.DisplayOrder = Icon.baseDisplayOrder
@@ -132,15 +134,15 @@ return function(Icon)
 	
 	local screenGuiClipped = screenGui:Clone()
 	screenGuiClipped.Name = screenGuiClipped.Name.."Clipped"
-	screenGuiClipped.DisplayOrder += 1
+	screenGuiClipped.DisplayOrder = Icon.baseDisplayOrder + 1
 	Icon.baseDisplayOrderChanged:Connect(function()
-		screenGuiClipped.DisplayOrder = Icon.baseDisplayOrder + 1
+		screenGuiClipped.DisplayOrder = (Icon.baseDisplayOrder + 1)
 	end)
 	container[screenGuiClipped.Name] = screenGuiClipped
 	
 	local screenGuiCenterClipped = screenGuiCenter:Clone()
 	screenGuiCenterClipped.Name = screenGuiCenterClipped.Name.."Clipped"
-	screenGuiCenterClipped.DisplayOrder += 1
+	screenGuiCenterClipped.DisplayOrder = (Icon.baseDisplayOrder + 1)
 	Icon.baseDisplayOrderChanged:Connect(function()
 		screenGuiCenterClipped.DisplayOrder = Icon.baseDisplayOrder + 1
 	end)


### PR DESCRIPTION
This fixes DisplayOrder being stuck at ``1`` despite default being at ``10``

Before:
<img width="321" height="80" alt="image" src="https://github.com/user-attachments/assets/f7542578-32ce-44ce-ac23-618850ffc366" />

After:
<img width="201" height="69" alt="image" src="https://github.com/user-attachments/assets/27e2638a-976c-4a29-b066-39d4ab2d4255" />

