### PR TITLE
Update noticeLabel font size property

### DIFF
--- a/src/Elements/Notice.lua
+++ b/src/Elements/Notice.lua
@@ -27,11 +27,10 @@ return function(icon, Icon)
 	noticeLabel.BackgroundTransparency = 1
 	noticeLabel.Position = UDim2.new(0.5, 0, 0.515, 0)
 	noticeLabel.BackgroundColor3 = Color3.fromRGB(0, 0, 0)
-	noticeLabel.FontSize = Enum.FontSize.Size14
+	noticeLabel.TextSize = 14
 	noticeLabel.TextColor3 = Color3.fromRGB(0, 0, 0)
 	noticeLabel.Text = "1"
 	noticeLabel.TextWrapped = true
-	noticeLabel.TextWrap = true
 	noticeLabel.Font = Enum.Font.Arial
 	noticeLabel.Parent = notice
 	


### PR DESCRIPTION
Removed "noticeLabel.TextWrap = true" as it was replaced with "noticeLabel.TextWrapped = true" and not removed.
Changed "noticeLabel.FontSize" to "noticeLabel.TextSize"

FontSize was deprecated in favor of TextSize: https://create.roblox.com/docs/reference/engine/classes/TextLabel#FontSize