### PR TITLE
Fix setTextFont using incorrect Enum

### DIFF
--- a/src/Types.lua
+++ b/src/Types.lua
@@ -241,7 +241,7 @@ type Methods = {
 			a font ID (such as <code>12187370928</code>),
 			or font family link (such as <code>"rbxasset://fonts/families/Sarpanch.json"</code>).
 		]]
-		function(self: Icon, font: string | Enum.Font, fontWeight: Enum.FontWeight?, fontStyle: Enum.FontSize?, iconState: IconState?): Icon
+		function(self: Icon, font: string | Enum.Font, fontWeight: Enum.FontWeight?, fontStyle: Enum.FontStyle?, iconState: IconState?): Icon
 			return nil :: any
 		end
 	),


### PR DESCRIPTION
Corrects `setTextFont` to use the proper enum for `fontStyle`. Previously, it would use `Enum.FontSize`, which would trigger a type warning if you were using `Enum.FontStyle`, which is the correct type.

I reviewed the rest of the code, which properly uses `Enum.FontStyle` is it's just a type on the types and not code.