### PR TITLE
Fix deprecated warnings

### DIFF
--- a/src/Elements/Notice.lua
+++ b/src/Elements/Notice.lua
@@ -27,11 +27,10 @@ return function(icon, Icon)
 	noticeLabel.BackgroundTransparency = 1
 	noticeLabel.Position = UDim2.new(0.5, 0, 0.515, 0)
 	noticeLabel.BackgroundColor3 = Color3.fromRGB(0, 0, 0)
-	noticeLabel.FontSize = Enum.FontSize.Size14
+	noticeLabel.TextSize = 14
 	noticeLabel.TextColor3 = Color3.fromRGB(0, 0, 0)
 	noticeLabel.Text = "1"
 	noticeLabel.TextWrapped = true
-	noticeLabel.TextWrap = true
 	noticeLabel.Font = Enum.Font.Arial
 	noticeLabel.Parent = notice
 	

--- a/src/Elements/Widget.lua
+++ b/src/Elements/Widget.lua
@@ -166,7 +166,6 @@ return function(icon, Icon)
 	iconLabel.TextXAlignment = Enum.TextXAlignment.Left
 	iconLabel.Text = ""
 	iconLabel.TextWrapped = true
-	iconLabel.TextWrap = true
 	iconLabel.TextScaled = false
 	iconLabel.Active = false
 	iconLabel.AutoLocalize = true

--- a/src/VERSION.lua
+++ b/src/VERSION.lua
@@ -20,7 +20,7 @@ function VERSION.getLatestVersion(): string?
 	local placeName = ""
 	while true do
 		local success, hdDevelopmentDetails = pcall(function()
-			return game:GetService("MarketplaceService"):GetProductInfo(DEVELOPMENT_PLACE_ID)
+			return game:GetService("MarketplaceService"):GetProductInfoAsync(DEVELOPMENT_PLACE_ID)
 		end)
 		if success and hdDevelopmentDetails then
 			placeName = hdDevelopmentDetails.Name


### PR DESCRIPTION
Fixes deprecated warnings by removing deprecated methods and using the up-to-date versions.

* Change usage of `FontSize` to `TextSize`
  * Both are the same but one uses a `Enum` instead of a `number`
* Remove `TextWrap`
  * `TextWrap` is an alias for `TextWrapped` which is already set
* Change [`GetProductInfo`](https://create.roblox.com/docs/reference/engine/classes/MarketplaceService#GetProductInfo) to [`GetProductInfoAsync`](https://create.roblox.com/docs/reference/engine/classes/MarketplaceService#GetProductInfoAsync)
  * Behaviors and API are exactly the same for both methods.

### Script Analysis Before

<img width="1127" height="305" alt="image" src="https://github.com/user-attachments/assets/3257d156-f3ed-42ce-b7e6-0075c022f50c" />

### Script Analysis After

<img width="1125" height="112" alt="image" src="https://github.com/user-attachments/assets/99298f4a-f51e-4b2f-9d4f-07826dca1433" />
