### PR TITLE
Fix type errors for Luau New Type Solver

### DIFF
--- a/src/Features/Themes/init.lua
+++ b/src/Features/Themes/init.lua
@@ -266,7 +266,8 @@ function Themes.set(icon, theme)
 		Themes.change(icon)
 	end))
 	if typeof(theme) == "Instance" and theme:IsA("ModuleScript") then
-		theme = require(theme)
+		local themeModule = theme :: ModuleScript
+		theme = require(themeModule)
 	end
 	icon.appliedTheme = theme
 	Themes.rebuild(icon)

--- a/src/Packages/Janitor.lua
+++ b/src/Packages/Janitor.lua
@@ -89,7 +89,7 @@ function Janitor.__index:Add(Object, MethodName, Index)
 	end
 	MethodName = MethodName or TypeDefaults[objectType] or "Destroy"
 	if type(Object) ~= "function" and not Object[MethodName] then
-		warn(string.format(METHOD_NOT_FOUND_ERROR, tostring(Object), tostring(MethodName), debug.traceback(nil :: any, 2)))
+		warn(string.format(METHOD_NOT_FOUND_ERROR, tostring(Object), tostring(MethodName), debug.traceback(nil, 2)))
 	end
 
 	local OriginalTraceback = debug.traceback("")

--- a/src/Types.lua
+++ b/src/Types.lua
@@ -241,7 +241,7 @@ type Methods = {
 			a font ID (such as <code>12187370928</code>),
 			or font family link (such as <code>"rbxasset://fonts/families/Sarpanch.json"</code>).
 		]]
-		function(self: Icon, font: string | Enum.Font, fontWeight: Enum.FontWeight?, fontStyle: Enum.FontSize?, iconState: IconState?): Icon
+		function(self: Icon, font: string | Enum.Font, fontWeight: Enum.FontWeight?, fontStyle: Enum.FontStyle?, iconState: IconState?): Icon
 			return nil :: any
 		end
 	),


### PR DESCRIPTION
Fixes type errors for TopbarPlus that are shown when the [Luau New Type Solver](https://devforum.roblox.com/t/general-release-luau%E2%80%99s-new-type-solver/4084991) beta is enabled.

This PR has been tested with the Luau New Type Solver enabled and disabled. With the Luau New Type Solver disabled, no new warnings are produced. This PR just solves warnings with the Luau New Type Solver enabled.

## Script Analysis Before

<img width="1117" height="297" alt="image" src="https://github.com/user-attachments/assets/f62ea35a-e5d7-4a54-ab39-b98ee8779f9f" />

## Script Analysis After

<img width="972" height="197" alt="image" src="https://github.com/user-attachments/assets/540f83b4-3201-40a1-a50e-726e7d3ac579" />
