### PR TITLE
Change captions to align text center

### DIFF
--- a/src/Elements/Caption.lua
+++ b/src/Elements/Caption.lua
@@ -48,6 +48,7 @@ return function(icon)
 	layout.Name = "Layout"
 	layout.Padding = UDim.new(0, 8)
 	layout.SortOrder = Enum.SortOrder.LayoutOrder
+	layout.HorizontalAlignment = Enum.HorizontalAlignment.Center
 	layout.Parent = box
 
 	local UICorner = Instance.new("UICorner")

--- a/src/Elements/Caption.lua
+++ b/src/Elements/Caption.lua
@@ -36,7 +36,6 @@ return function(icon)
 	header.TextSize = TEXT_SIZE
 	header.TextTruncate = Enum.TextTruncate.None
 	header.TextWrapped = false
-	header.TextXAlignment = Enum.TextXAlignment.Left
 	header.AutomaticSize = Enum.AutomaticSize.X
 	header.BackgroundTransparency = 1
 	header.LayoutOrder = 1


### PR DESCRIPTION
Makes text that is smaller than the binded hotkey become aligned to the center instead of the left. Before, only the hotkey would be centered aligned if it was smaller than the text.

Related to https://github.com/1ForeverHD/TopbarPlus/issues/193, but doesn't fully close it. 

## Before
<img width="261" height="154" alt="default-inventory-key-caption-1" src="https://github.com/user-attachments/assets/01d89519-a97e-42e9-b21e-3b570246f317" />

## After
<img width="261" height="154" alt="default-inventory-key-caption" src="https://github.com/user-attachments/assets/a9256972-8313-4918-a823-29e9d62f2d19" />
