### PR TITLE
Fix Wally license link

### DIFF
--- a/wally.toml
+++ b/wally.toml
@@ -1,7 +1,7 @@
 [package]
 name = "1foreverhd/topbarplus"
 description = "Construct dynamic and intuitive topbar icons. Enhance the appearance and behaviour of these icons with features such as themes, dropdowns and menus."
-license = "MPL2"
+license = "MPL-2.0"
 version = "3.4.0"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"


### PR DESCRIPTION
Updates the `wally.toml` to use the [MPL-2.0 SPDX short identifier](https://spdx.org/licenses/preview/MPL-2.0.html) so Wally links to the proper license.

Currently, the [TopbarPlus Wally package](https://wally.run/package/1foreverhd/topbarplus) links to the identifier `MPL2`, which is invalid.

<img width="1153" height="405" alt="image" src="https://github.com/user-attachments/assets/43e81c53-ba5d-4846-88ec-99f5117faafa" />

This just changes the identifier to `MPL-2.0` which properly links when you press it.