### PR TITLE
Add Wally repository key

### DIFF
--- a/wally.toml
+++ b/wally.toml
@@ -5,6 +5,7 @@ license = "MPL2"
 version = "3.4.0"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
+repository = "https://github.com/1ForeverHD/TopbarPlus"
 exclude = [
     "**",
 ]


### PR DESCRIPTION
Add the repository to the [Wally package manifest file](https://github.com/UpliftGames/wally?tab=readme-ov-file#manifest-format), so Wally displays the repository link

## Before

<img width="386" height="353" alt="image" src="https://github.com/user-attachments/assets/bdf7594e-6fdd-4442-9296-d78b9dcda10d" />

## After

<img width="403" height="420" alt="image" src="https://github.com/user-attachments/assets/1fb937b6-ca78-498a-9a2f-1b98e7be89d6" />
