### PR TITLE
Fix missing export Fields type for Icon

### DIFF
--- a/src/Types.lua
+++ b/src/Types.lua
@@ -461,7 +461,7 @@ type Fields = {
 	notified: Signal,
 }
 
-export type Icon = Methods & StaticFunctions --typeof(setmetatable({} :: Fields, MT))
+export type Icon = Methods & Fields & StaticFunctions --typeof(setmetatable({} :: Fields, MT))
 
 export type StaticIcon = {
 	new: typeof(


### PR DESCRIPTION
Fixes the `Icon` type, which is missing properties and events such as `isEnabled` and `selected`.

Reproduction:
```luau
icon.toggled:Connect(function()
	print("Toggled")
end)
```

Closes #214

## Before

<img width="1799" height="493" alt="image" src="https://github.com/user-attachments/assets/68012228-df31-4cbb-bf35-fbef11d8e4c7" />

## After

<img width="843" height="247" alt="image" src="https://github.com/user-attachments/assets/b3dfe9a2-4930-4ce3-ac07-3ba7a0de2f4c" />
