### PR TITLE
Add Wally homepage key

### DIFF
--- a/wally.toml
+++ b/wally.toml
@@ -5,6 +5,7 @@ license = "MPL2"
 version = "3.4.0"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
+homepage = "https://1foreverhd.github.io/TopbarPlus"
 exclude = [
     "**",
 ]


### PR DESCRIPTION
Add [docs site](https://1foreverhd.github.io/TopbarPlus) as homepage to the [Wally package manifest file](https://github.com/UpliftGames/wally?tab=readme-ov-file#manifest-format).

## Before

<img width="566" height="697" alt="image" src="https://github.com/user-attachments/assets/77923591-4ed5-4784-9763-7f32b7b324be" />

## After

<img width="608" height="672" alt="image" src="https://github.com/user-attachments/assets/5abf33ae-8568-4e07-96a4-26dfaf99fd5c" />
