### PR TITLE
Replace `disableStateOverlay` in docs with `disableOverlay`

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -135,7 +135,7 @@ icon:clearNotices()
 #### disableOverlay
 {chainable}
 ```lua
-icon:disableStateOverlay(bool)
+icon:disableOverlay(bool)
 ```
 When set to ``true``, disables the shade effect which appears when the icon is pressed and released.
 


### PR DESCRIPTION
Fixes docs inconsistency with `disableStateOverlay` and `disableOverlay` being used for header and code by replacing with `disableOverlay`.

Closes https://github.com/1ForeverHD/TopbarPlus/issues/213