### PR TITLE
Display current app version when update is available

### DIFF
--- a/src/Attribute.lua
+++ b/src/Attribute.lua
@@ -28,7 +28,7 @@ task.defer(function()
 		print(`🍍 Running TopbarPlus {appVersion} by @ForeverHD & HD Admin`)
 	end
 	if isOutdated then
-		warn(`A new version of TopbarPlus ({latestVersion}) is available: https://devforum.roblox.com/t/topbarplus/1017485`)
+		warn(`A new version of TopbarPlus ({appVersion} -> {latestVersion}) is available: https://devforum.roblox.com/t/topbarplus/1017485`)
 	end
 end)
 


### PR DESCRIPTION
Currently, when an update is available, the warning in Roblox Studio's output doesn't show the current version, and you either need to open the script to view it or join a live experience (the current version isn't printed in Roblox Studio).

> `A new version of TopbarPlus (v3.4.0) is available: https://devforum.roblox.com/t/topbarplus/1017485`

This PR updates the warning to display the current and latest versions so that developers can compare the changelog and understand the version difference more easily.

> `A new version of TopbarPlus (v3.3.1 -> v3.4.0) is available: https://devforum.roblox.com/t/topbarplus/1017485`
